### PR TITLE
path.sep not required, / is supported on Windows and required for some

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@ const client = new Discord.Client();
 const config = require('./config.json');
 require('discord.js-aliases');
 const fs = require("fs-extra");
-const { sep } = require("path");
 
 // Readline module test
 const readline = require('readline');
@@ -46,9 +45,11 @@ fs.readdir('./events/', (err, files) => {
   console.log(`Loading a total of ${files.length} events.`);
   files.forEach(file => {
     const eventName = file.split(".")[0];
-    const event = require(`.${sep}events${sep}${file}`);
+    // Forward slash (/) is also supported on Windows and required on some machines.
+    // Source: https://nodejs.org/api/path.html#path_path_sep
+    const event = require(`./events/${file}`);
     client.on(eventName, event.bind(null, client));
-    delete require.cache[require.resolve(`.${sep}events${sep}${file}`)];
+    delete require.cache[require.resolve(`./events/${file}`)];
   });
 });
 

--- a/commands/reload.js
+++ b/commands/reload.js
@@ -1,5 +1,3 @@
-const path = require("path");
-
 exports.run = async (client, msg, args) => {
   if(!args || args.size < 1) return msg.edit(`Must provide a command to reload. Derp.`).then(setTimeout(msg.delete.bind(msg), 1000));
 
@@ -12,7 +10,9 @@ exports.run = async (client, msg, args) => {
   if(!command) return msg.edit(`The command \`${args[0]}\` doesn't seem to exist, nor is it an alias. Try again!`).then(setTimeout(msg.delete.bind(msg), 1000));
   command = command.help.name;
 
-  delete require.cache[require.resolve(`.${path.sep}${command}.js`)];
+  // Forward slash (/) is also supported on Windows and required on some machines.
+  // Source: https://nodejs.org/api/path.html#path_path_sep
+  delete require.cache[require.resolve(`./${command}.js`)];
   let cmd = require(`./${command}`);
   client.commands.delete(command);
   client.aliases.forEach((cmd, alias) => {


### PR DESCRIPTION
According to [the node.js docs,](https://nodejs.org/api/path.html#path_path_sep)

> *Note*: On Windows, both the forward slash (/) and backward slash (\\) are accepted as path segment separators; however, the `path` methods only add backward slashes (\\).

As the only use was to "fix" the paths passed to `require`, it's useless. Furthermore, on some machines (Windows 10, node 8.0 and 8.1), it simply failed with the backslash:

```
Uncaught Exception:  Error: Cannot find module '.\events\error.js'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at files.forEach.file (D:\Repos\evie.selfbot\app.js:49:19)
    at Array.forEach (native)
    at fs.readdir (D:\Repos\evie.selfbot\app.js:47:9)
    at D:\Repos\evie.selfbot\node_modules\graceful-fs\graceful-fs.js:142:16
    at FSReqWrap.oncomplete (fs.js:135:15)
```

It seems like `require` parses the passed path differently.

Dropping `path.sep` and hardcoding `/` may seem horrible, but in this case, it really isn't.