### PR TITLE
Update message.js to allow startup without errors

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -2,7 +2,7 @@
 const warned = [];
 
 module.exports = async (client, message) => {
-  if(message.mentions.has(client.user.id) || message.mentions.everyone || (message.guild && message.mentions.roles.filter(r=>message.guild.member(client.user.id).roles.has(r.id)).size > 0)) {
+  if(message.mentions.users.has(client.user.id) || message.mentions.everyone || (message.guild && message.mentions.roles.filter(r=>message.guild.member(client.user.id).roles.has(r.id)).size > 0)) {
     const chan = !!message.guild ? `${message.guild.name} #${message.channel.name}` : "";
     client.log("mention", chan, message.author, message.cleanContent);
   }


### PR DESCRIPTION
Fixes error thrown on startup. message.mentions.has is the wrong syntax. See https://discord.js.org/#/docs/main/stable/class/MessageMentions

Edit:

Forgot screencap, had it on my clipboard however.
Before:
![](https://you.cant-even-touch.me/532acf.png)
After:
![](https://you.cant-even-touch.me/aba61d.png)