### PR TITLE
Fix no argument check in reload command

### DIFF
--- a/commands/reload.js
+++ b/commands/reload.js
@@ -1,5 +1,5 @@
 exports.run = async (client, msg, args) => {
-  if(!args || args.size < 1) return msg.edit(`Must provide a command to reload. Derp.`).then(setTimeout(msg.delete.bind(msg), 1000));
+  if(!args.length) return msg.edit(`Must provide a command to reload. Derp.`).then(setTimeout(msg.delete.bind(msg), 1000));
 
   let command;
   if (client.commands.has(args[0])) {


### PR DESCRIPTION
`args` is an array, not a map or collection, so `args.size` => `args.length`